### PR TITLE
[TASK] Remove version from Composer manifest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,5 @@
 	"keywords": ["TYPO3 CMS", "Media management"],
 	"support": {
 		"issues": "https://github.com/fabarea/media/issues"
-	},
-	"version": "3.6.0-dev"
+	}
 }


### PR DESCRIPTION
The version specification is not necessary since Composer is able to derive
versions from VCS.
