### PR TITLE
[BUGFIX] Saving content doesn't work in a workspace (refs #39)

### DIFF
--- a/Classes/Hook/DataHandlerHook.php
+++ b/Classes/Hook/DataHandlerHook.php
@@ -211,13 +211,14 @@ class DataHandlerHook {
 		if (isset($indexes['relations'])) {
 
 			foreach ($indexes['relations'] as $index) {
-
-				if ($this->isSoftReferenceImage($index)) {
-					$fileIdentifiers[] = $index['ref_uid'];
-				} elseif ($this->isSoftReferenceLink($index)) {
-					$fileIdentifiers[] = $index['ref_uid'];
-				} elseif ($this->isFileReference($index)) {
-					$fileIdentifiers[] = $this->findFileByFileReference($index['ref_uid']);
+				if (is_array($index)) {
+					if ($this->isSoftReferenceImage($index)) {
+						$fileIdentifiers[] = $index['ref_uid'];
+					} elseif ($this->isSoftReferenceLink($index)) {
+						$fileIdentifiers[] = $index['ref_uid'];
+					} elseif ($this->isFileReference($index)) {
+						$fileIdentifiers[] = $this->findFileByFileReference($index['ref_uid']);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Media uses a DataHandler hook to the the number of file references
up-to-date. It expects data that can be empty if it is called in
a workspace context. Therefore an additional check must be added
to prevent a fatal error in workspace context.
