### PR TITLE
[BUGFIX] Add setEvaluatePermissions to ThumbnailCommandController

### DIFF
--- a/Classes/Command/ThumbnailCommandController.php
+++ b/Classes/Command/ThumbnailCommandController.php
@@ -49,6 +49,9 @@ class ThumbnailCommandController extends CommandController
 
             if ($storage->isOnline()) {
 
+                // For the CLI cause.
+                $storage->setEvaluatePermissions(FALSE);
+
                 $thumbnailGenerator = $this->getThumbnailGenerator();
                 $thumbnailGenerator
                     ->setStorage($storage)


### PR DESCRIPTION
If you have different permissions on FAL storages the task needs
full permissions
