### PR TITLE
[BUGFIX] Only display writable files in duplicate files finder

### DIFF
--- a/Classes/Tool/DuplicateFilesFinderTool.php
+++ b/Classes/Tool/DuplicateFilesFinderTool.php
@@ -80,6 +80,9 @@ class DuplicateFilesFinderTool extends AbstractTool {
 
 			$allowedStorages = array();
 			foreach ($fileMounts as $fileMount) {
+                if ((bool)$fileMount['read_only']) {
+                    continue;
+                }
 
 				if (!isset($allowedStorages[$fileMount['base']])) {
 					$allowedStorages[$fileMount['base']] = array();


### PR DESCRIPTION
Currently, the duplicate files finder displays the files of all
filemounts, including files of read-only filemounts. This will
cause removing duplicates to fail because of missing write
permissions. A check for the read_only flag is therefore added.
