### PR TITLE
[TASK] Make ConflictMode configurable

### DIFF
--- a/Classes/Controller/Backend/AssetController.php
+++ b/Classes/Controller/Backend/AssetController.php
@@ -114,6 +114,9 @@ class AssetController extends ActionController {
 
 		try {
 			$conflictMode = 'changeName';
+			if($this->getMediaModule()->replaceExistingFile()){
+				$conflictMode = 'replace';
+			}
 			$fileName = $uploadedFile->getName();
 			$file = $targetFolder->addFile($uploadedFile->getFileWithAbsolutePath(), $fileName, $conflictMode);
 

--- a/Classes/Module/MediaModule.php
+++ b/Classes/Module/MediaModule.php
@@ -252,6 +252,17 @@ class MediaModule implements SingletonInterface {
 		$configuration = $this->getModuleConfiguration();
 		return !(bool)$configuration['has_media_file_picker']['value'];
 	}
+	
+	
+	/**
+	* Tell whether the file will be replaced or renamed
+	*
+	* @return bool
+	*/
+	public function replaceExistingFile() {
+		$configuration = $this->getModuleConfiguration();
+		return (bool)$configuration['replace_existing_file']['value'];
+	}
 
 	/**
 	 * Tell whether the sub-folders must be included when browsing.

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -13,6 +13,10 @@ has_media_file_picker = 0
 # cat=basic//; type=boolean; label= Hide default file list : If checked, the default file list is hidden which allows to gain some room. Reload the Backend after enabling this option.
 hide_file_list = 0
 
+# cat=basic//; type=boolean; label= Replace existing files: If checked, a new file will not be renamed if it already exists but the existing file will be replaced.
+replace_existing_file = 0
+
+
 ###################### Image preset ######################
 
 # cat=image preset//2; type=string; label= Maximum size of thumbnail image: Define the max width and height of a thumbnail. This setting is currently used for thumbnails in the Grid in the BE.


### PR DESCRIPTION
The ConflictMode for createAction is hardcoded to 'changeName'. We implemented a kind of "archive"-function which needed conflictMode to be 'replace' instead, so we figured we would make it configurable in the extension configuration.
