### PR TITLE
[WIP/FEATURE] Support TYPO3 Flash-Messages

### DIFF
--- a/Resources/Private/Backend/Standalone/FileUploadTceFormsTemplate.html
+++ b/Resources/Private/Backend/Standalone/FileUploadTceFormsTemplate.html
@@ -33,6 +33,7 @@
 				<a class="qq-upload-continue-selector btn-small btn-info" href="#">
 					{f:translate(key: 'media_file_upload.continue',extensionName: 'media')}</a>
 				<span class="qq-upload-status-text-selector qq-upload-status-text"></span>
+				<div id="typo3-messages"></div>
 			</li>
 		</ul>
 	</div>

--- a/Resources/Private/Backend/Standalone/FileUploadTemplate.html
+++ b/Resources/Private/Backend/Standalone/FileUploadTemplate.html
@@ -38,6 +38,7 @@
 				<span class="qq-upload-status-text-selector qq-upload-status-text"></span>
 				<a class="view-btn btn-small btn-info hide" target="_blank">
 					{f:translate(key: 'media_file_upload.view',extensionName: 'media')}</a>
+				<div id="typo3-messages"></div>
 			</li>
 		</ul>
 	</div>

--- a/Resources/Public/Libraries/Fineuploader/jquery.fineuploader-5.0.9.js
+++ b/Resources/Public/Libraries/Fineuploader/jquery.fineuploader-5.0.9.js
@@ -4417,6 +4417,14 @@ qq.UploadHandlerController = function(o, namespace) {
 
                 function(response, opt_xhr) {
                     log("Simple upload request failed for " + id);
+		    $.ajax({
+			url: TYPO3.settings.ajaxUrls['DocumentTemplate::getFlashMessages'],
+			cache: false,
+			success: function(data) {
+			    var messages = $('#typo3-messages');
+			    messages.replaceWith(data);
+			}
+		    });
 
                     var responseToReport = upload.normalizeResponse(response, false);
 


### PR DESCRIPTION
Currently, if upload fails, it just cumulates the flash error messages and prints them on the next page (which might or might not be related to the upload page). We tried to add output of these messages, but it's probably not a good idea to modify fineuploader. However we failed to find a place where the changes would fit in better. Do you have a better idea? :)
