### PR TITLE
fixes exception #1437750231 for typo3 7+

### DIFF
--- a/Configuration/TCA/Overrides/sys_file_storage.php
+++ b/Configuration/TCA/Overrides/sys_file_storage.php
@@ -105,7 +105,9 @@ if (!$configuration['has_folder_tree']['value']) {
 					'wizards' => array(
 						'edit' => array(
 							'type' => 'popup',
-							'script' => 'wizard_edit.php',
+							'module' => array(
+								'name' => 'wizard_edit',
+							),
 							'icon' => 'edit2.gif',
 							'popup_onlyOpenIfSelected' => 1,
 							'notNewRecords' => 1,
@@ -126,7 +128,9 @@ if (!$configuration['has_folder_tree']['value']) {
 					'wizards' => array(
 						'edit' => array(
 							'type' => 'popup',
-							'script' => 'wizard_edit.php',
+							'module' => array(
+								'name' => 'wizard_edit',
+							),
 							'icon' => 'edit2.gif',
 							'popup_onlyOpenIfSelected' => 1,
 							'notNewRecords' => 1,
@@ -147,7 +151,9 @@ if (!$configuration['has_folder_tree']['value']) {
 					'wizards' => array(
 						'edit' => array(
 							'type' => 'popup',
-							'script' => 'wizard_edit.php',
+							'module' => array(
+								'name' => 'wizard_edit',
+							),
 							'icon' => 'edit2.gif',
 							'popup_onlyOpenIfSelected' => 1,
 							'notNewRecords' => 1,
@@ -168,7 +174,9 @@ if (!$configuration['has_folder_tree']['value']) {
 					'wizards' => array(
 						'edit' => array(
 							'type' => 'popup',
-							'script' => 'wizard_edit.php',
+							'module' => array(
+								'name' => 'wizard_edit',
+							),
 							'icon' => 'edit2.gif',
 							'popup_onlyOpenIfSelected' => 1,
 							'notNewRecords' => 1,
@@ -189,7 +197,9 @@ if (!$configuration['has_folder_tree']['value']) {
 					'wizards' => array(
 						'edit' => array(
 							'type' => 'popup',
-							'script' => 'wizard_edit.php',
+							'module' => array(
+								'name' => 'wizard_edit',
+							),
 							'icon' => 'edit2.gif',
 							'popup_onlyOpenIfSelected' => 1,
 							'notNewRecords' => 1,


### PR DESCRIPTION
https://wiki.typo3.org/Exception/CMS/1437750231
#1437750231: The way registering a wizard in TCA has changed in 6.2 and was removed in CMS 7. Please set module[name]=module_name instead of using script=path/to/script.php in your TCA
