### PR TITLE
[BUGFIX] Added correct vidi version to dependencies

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -24,7 +24,7 @@ $EM_CONF[$_EXTKEY] = array (
     'depends' =>
     array (
       'typo3' => '6.2.0-6.2.99',
-      'vidi' => '',
+      'vidi' => '1.3.1-1.3.99',
     ),
     'conflicts' =>
     array (


### PR DESCRIPTION
Media  3.7.5 installs vidi 2.1.0 which doesn't work for typo3 6.2
