### PR TITLE
Use native TYPO3 JS parameter to set and remember the chosen id (folder)

### DIFF
--- a/Classes/Module/MediaModule.php
+++ b/Classes/Module/MediaModule.php
@@ -147,7 +147,7 @@ class MediaModule implements SingletonInterface {
 	 *
 	 * @return string
 	 */
-	public function getCombinedIdentifier() {
+	public static function getCombinedIdentifier() {
 
 		// Fetch possible combined identifier.
 		$combinedIdentifier = GeneralUtility::_GET('id');
@@ -158,7 +158,7 @@ class MediaModule implements SingletonInterface {
 			// Add a loop to decode maximum 999 time!
 			$semaphore = 0;
 			$semaphoreLimit = 999;
-			while (!$this->isWellDecoded($combinedIdentifier) && $semaphore < $semaphoreLimit) {
+			while (!self::isWellDecoded($combinedIdentifier) && $semaphore < $semaphoreLimit) {
 				$combinedIdentifier = urldecode($combinedIdentifier);
 				$semaphore++;
 			}
@@ -171,7 +171,7 @@ class MediaModule implements SingletonInterface {
 	 * @param $combinedIdentifier
 	 * @return bool
 	 */
-	protected function isWellDecoded($combinedIdentifier) {
+	protected static function isWellDecoded($combinedIdentifier) {
 		return preg_match('/.*:.*/', $combinedIdentifier);
 	}
 
@@ -196,7 +196,7 @@ class MediaModule implements SingletonInterface {
 	 */
 	public function getCurrentFolder() {
 
-		$combinedIdentifier = $this->getCombinedIdentifier();
+		$combinedIdentifier = self::getCombinedIdentifier();
 
 		if ($combinedIdentifier) {
 			$folder = $this->getFolderForCombinedIdentifier($combinedIdentifier);

--- a/Classes/View/InlineJavaScript.php
+++ b/Classes/View/InlineJavaScript.php
@@ -30,10 +30,12 @@ class InlineJavaScript extends AbstractComponentView {
 	 */
 	public function render() {
 		$parameterPrefix = MediaModule::getParameterPrefix();
+                $id = MediaModule::getCombinedIdentifier();
 		$output = "
 <script>
 
 Media.parameterPrefix = '${parameterPrefix}';
+top.fsMod.recentIds['file'] = '${id}';
 
 </script>";
 


### PR DESCRIPTION
When a folder is chosen inside the Media extension, and the user navigates away from the module Media (for instance, to the File module) and navigates back to the Media module, the current selected folder is not remembered. By settings JS-variable "top.fsMod.recentIds['file']", we're using native TYPO3 functionality (used by the module Filelist) to set the current selected folder.

Note: has_folder_tree should be set.
