### PR TITLE
When editing a file reference (usage) the returnUrl should respect the current id (folder)

### DIFF
--- a/Classes/Grid/UsageRenderer.php
+++ b/Classes/Grid/UsageRenderer.php
@@ -14,6 +14,7 @@ namespace Fab\Media\Grid;
  * The TYPO3 project - inspiring people to share!
  */
 
+use Fab\Media\Module\MediaModule;
 use Fab\Media\Module\VidiModule;
 use Fab\Vidi\Grid\ColumnRendererAbstract;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
@@ -114,7 +115,7 @@ class UsageRenderer extends ColumnRendererAbstract {
 	 */
 	protected function getModuleUrl() {
 		$moduleSignature = VidiModule::getSignature();
-		return rawurlencode(BackendUtility::getModuleUrl($moduleSignature));
+		return rawurlencode(BackendUtility::getModuleUrl($moduleSignature) . '&id=' . MediaModule::getCombinedIdentifier());
 	}
 
 	/**

--- a/Classes/Module/MediaModule.php
+++ b/Classes/Module/MediaModule.php
@@ -147,7 +147,7 @@ class MediaModule implements SingletonInterface {
 	 *
 	 * @return string
 	 */
-	public function getCombinedIdentifier() {
+	public static function getCombinedIdentifier() {
 
 		// Fetch possible combined identifier.
 		$combinedIdentifier = GeneralUtility::_GET('id');
@@ -158,7 +158,7 @@ class MediaModule implements SingletonInterface {
 			// Add a loop to decode maximum 999 time!
 			$semaphore = 0;
 			$semaphoreLimit = 999;
-			while (!$this->isWellDecoded($combinedIdentifier) && $semaphore < $semaphoreLimit) {
+			while (!self::isWellDecoded($combinedIdentifier) && $semaphore < $semaphoreLimit) {
 				$combinedIdentifier = urldecode($combinedIdentifier);
 				$semaphore++;
 			}
@@ -171,7 +171,7 @@ class MediaModule implements SingletonInterface {
 	 * @param $combinedIdentifier
 	 * @return bool
 	 */
-	protected function isWellDecoded($combinedIdentifier) {
+	protected static function isWellDecoded($combinedIdentifier) {
 		return preg_match('/.*:.*/', $combinedIdentifier);
 	}
 
@@ -196,7 +196,7 @@ class MediaModule implements SingletonInterface {
 	 */
 	public function getCurrentFolder() {
 
-		$combinedIdentifier = $this->getCombinedIdentifier();
+		$combinedIdentifier = self::getCombinedIdentifier();
 
 		if ($combinedIdentifier) {
 			$folder = $this->getFolderForCombinedIdentifier($combinedIdentifier);

--- a/Classes/View/InlineJavaScript.php
+++ b/Classes/View/InlineJavaScript.php
@@ -30,10 +30,12 @@ class InlineJavaScript extends AbstractComponentView {
 	 */
 	public function render() {
 		$parameterPrefix = MediaModule::getParameterPrefix();
+                $id = MediaModule::getCombinedIdentifier();
 		$output = "
 <script>
 
 Media.parameterPrefix = '${parameterPrefix}';
+top.fsMod.recentIds['file'] = '${id}';
 
 </script>";
 


### PR DESCRIPTION
When editing a file reference (usage) the returnUrl should respect the current id (folder)
