### PR TITLE
ThumbnailViewHelper: make sure configuration is of type array #4915

### DIFF
--- a/Classes/ViewHelpers/File/ThumbnailViewHelper.php
+++ b/Classes/ViewHelpers/File/ThumbnailViewHelper.php
@@ -46,6 +46,9 @@ class ThumbnailViewHelper extends AbstractViewHelper
         $file = $this->arguments['file'];
         $preset = $this->arguments['preset'];
         $configuration = $this->arguments['configuration'];
+        if (!is_array($configuration)) {
+            $configuration = array();
+        }
         $configurationWrap = $this->arguments['configurationWrap'];
         $attributes = $this->arguments['attributes'];
         $output = $this->arguments['output'];
@@ -55,13 +58,11 @@ class ThumbnailViewHelper extends AbstractViewHelper
         } elseif (!($file instanceof File)) {
             $file = ResourceFactory::getInstance()->getFileObject((int)$file);
         }
-
         if ($preset) {
             $imageDimension = ImagePresetUtility::getInstance()->preset($preset);
             $configuration['width'] = $imageDimension->getWidth();
             $configuration['height'] = $imageDimension->getHeight();
         }
-
         /** @var $thumbnailService \Fab\Media\Thumbnail\ThumbnailService */
         $thumbnailService = GeneralUtility::makeInstance('Fab\Media\Thumbnail\ThumbnailService', $file);
         $thumbnail = $thumbnailService->setConfiguration($configuration)


### PR DESCRIPTION
When inserting a media into a Content Element in the RdA project, we got the following error in the `ImageEditor::Show` dialog: 

```
Argument 1 passed to Fab\Media\Thumbnail\ImageThumbnailProcessor::computeFinalImageDimension() must be of the type array, string given, called in ./htdocs/typo3conf/ext/media/Classes/Thumbnail/ImageThumbnailProcessor.php on line 62
```

It seems the `ThumbnailViewHelper` used in this dialog got a wrong configuration which is not of type array, so this fix makes sure the configuration is of type array.