### PR TITLE
[BUGFIX] Prevent Upgrade Wizard crash in TYPO3 v8

### DIFF
--- a/Configuration/TCA/Overrides/sys_file_metadata.php
+++ b/Configuration/TCA/Overrides/sys_file_metadata.php
@@ -14,7 +14,6 @@ $tca = [
     ],
     'columns' => [
         'fileinfo' => [
-            'l10n_mode' => 'exclude',
             'config' => [
                 'type' => 'user',
                 'userFunc' => 'EXT:media/Classes/Backend/TceForms.php:Fab\Media\Backend\TceForms->renderFileUpload',


### PR DESCRIPTION
Virtual column `fileinfo` from table `sys_file_metadata` should not
get a configuration for `l10n_mode`.

Resolves: #176