### PR TITLE
[BUGFIX] Prevent another possible crash when upgrading to TYPO3 v8

### DIFF
--- a/Configuration/TCA/Overrides/sys_file_metadata.php
+++ b/Configuration/TCA/Overrides/sys_file_metadata.php
@@ -20,7 +20,7 @@ $tca = [
             ],
         ],
         'related_files' => [
-            'l10n_mode' => 'exclude',
+            'displayCond' => 'FIELD:sys_language_uid:<=:0',
             'label' => 'LLL:EXT:media/Resources/Private/Language/locallang_db.xlf:sys_file_metadata.relations',
             'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig(
                 'related_files',


### PR DESCRIPTION
Upgrade Wizard "Execute database migrations on single rows" may fail to update
child record (which are actually non-existing) on column related_files.

Using a displayCond TCA definition since "related_files" is a real column and
the behaviour requested by EXT:media is to exclude it when a sys_file_metadata
row is edited/processed.

Resolves: #178