### PR TITLE
[FIX] Compatibility with TYPO3 CMS 8 for Media File Picker

### DIFF
--- a/Resources/Public/JavaScript/MediaFormEngine.js
+++ b/Resources/Public/JavaScript/MediaFormEngine.js
@@ -15,7 +15,7 @@ define('TYPO3/CMS/Media/MediaFormEngine', ['jquery', 'TYPO3/CMS/Backend/FormEngi
 	// main options
 	var FormEngine = {
 		formName: TYPO3.settings.FormEngine.formName
-		,backPath: TYPO3.settings.FormEngine.backPath
+		,backPath: TYPO3.settings.FormEngine.backPath || ''
 		,openedPopupWindow: null
 		,legacyFieldChangedCb: function() { !$.isFunction(TYPO3.settings.FormEngine.legacyFieldChangedCb) || TYPO3.settings.FormEngine.legacyFieldChangedCb(); }
 	};


### PR DESCRIPTION
This change allows the Media File Picker to be called in TYPO3 CMS 8 without 404 HTTP error.

It seems that the variable `TYPO3.settings.FormEngine.backPath` is not available anymore. In any case, the variable `MediaFormEngine.vidiModuleUrl` contains the whole relative path that is needed to call the Backend module.

Tested with TYPO3 8.7.1