### PR TITLE
[BUGFIX] Preserve storage selection menu when editing a record

### DIFF
--- a/Classes/View/Button/EditButton.php
+++ b/Classes/View/Button/EditButton.php
@@ -14,6 +14,7 @@ use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Fab\Vidi\View\AbstractComponentView;
 use Fab\Vidi\Domain\Model\Content;
+use Fab\Media\Module\VidiModule;
 
 /**
  * View which renders a "edit" button to be placed in the grid.
@@ -73,13 +74,19 @@ class EditButton extends AbstractComponentView
      */
     protected function getAdditionalParameters()
     {
-
         $additionalParameters = [];
         if (GeneralUtility::_GP('id')) {
-            $additionalParameters = array(
-                'id' => urldecode(GeneralUtility::_GP('id')),
-            );
+            $additionalParameters['id'] = urldecode(GeneralUtility::_GP('id'));
         }
+
+        $vidiParameters = GeneralUtility::_GP(VidiModule::PARAMETER_PREFIX);
+        if (is_array($vidiParameters)) {
+            $whitelistedParameters = array_intersect_key($vidiParameters, ['plugins' => true, 'matches' => true]);
+            if (count($whitelistedParameters) === 2) {
+                $additionalParameters[VidiModule::PARAMETER_PREFIX] = $whitelistedParameters;
+            }
+        }
+
         return $additionalParameters;
     }
 


### PR DESCRIPTION
When inserting a media into RTE, a popup window will open to select the media.
This window shows a selectbox menu for storage selection, but this menu
disappeared if user edited a record and closed it. Instead of the menu a
checkbox "Browse subfolders" was displayed.

By forwarding specific parameters to the edit button `returnUrl` parameter,
we are now able to preserve the storage menu selection, when the user comes
back from the edit page.

Resolves #181