### PR TITLE
[BUGFIX] Find file uids even in sub folders

### DIFF
--- a/Classes/Security/FilePermissionsAspect.php
+++ b/Classes/Security/FilePermissionsAspect.php
@@ -125,6 +125,10 @@ class FilePermissionsAspect
         foreach ($folder->getFiles() as $file) {
             $files[] = $file->getUid();
         }
+        /** @var Folder $subfolder */
+        foreach ($folder->getSubfolders() as $subfolder) {
+            $files = array_merge($files, $this->getFileUids($subfolder));
+        }
         return $files;
     }
 


### PR DESCRIPTION
I think, when file uids are fetched, subfolders should be respected, too. Or am I wrong?