### PR TITLE
Keep a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 5.1.0
+
+⚠️ This version contains breaking changes.
+
+### Changed
+* Use Doctrine database connection instead of TYPO3_DB
+* Require `vidi`-extension version `4.0`
+
+### Removed
+* `\Fab\Media\Cache\CacheService::findPagesWithSoftReferences`


### PR DESCRIPTION
Keeping a changelog will help developers to track changes.
Please refer to the «Keep a changelog» documentation:
https://keepachangelog.com/en/1.0.0/

Furthermore the changelog documentation emphasizes to use semantic versioning.
Please refer to the «Semantic Versioning» documentation:
https://semver.org/spec/v2.0.0.html

In this extension both concepts became relevant with version 5.1.0:
It contains several breaking changes. Neither the release notes nor the version number indicated about this.

Applying both concepts can improve the developer expirience.