### PR TITLE
[BUGFIX] flushProcessedFilesCommand: Don't try flushing files if stor…

### DIFF
--- a/Classes/Command/FileCacheCommandController.php
+++ b/Classes/Command/FileCacheCommandController.php
@@ -49,11 +49,17 @@ class FileCacheCommandController extends CommandController
                 $this->outputLine(sprintf('%s (%s)', $storage->getName(), $storage->getUid()));
                 $this->outputLine('--------------------------------------------');
                 $this->outputLine();
+                
+                $processingFolderPublicUrl = $storage->getProcessingFolder()->getPublicUrl();
+                if (!$processingFolderPublicUrl) {
+                    $this->outputLine('Skipped because storage is not publicly available.');
+                    continue;
+                }
 
                 #$storage->getProcessingFolder()->delete(true); // will not work
 
                 // Well... not really FAL friendly but straightforward for Local drivers.
-                $processedDirectoryPath = PATH_site . $storage->getProcessingFolder()->getPublicUrl();
+                $processedDirectoryPath = PATH_site . $processingFolderPublicUrl;
                 $fileIterator = new FilesystemIterator($processedDirectoryPath, FilesystemIterator::SKIP_DOTS);
                 $numberOfProcessedFiles = iterator_count($fileIterator);
 


### PR DESCRIPTION
…age is not publicly available

The flushProcessedFiles command flushes all processed files of all storages.

To find the appropriate folder, the publicUrl of the Storage's processingFolder is looked up.
However, there is no publicUrl for a Storage that is not publicly available. This is usually the
case if you have protected file areas.

In this case, the contents of PATH_SITE are deleted which is no desirable. With this change,
the command skips storages that have no publicly available processingFolder.

Resolves: #209